### PR TITLE
修复思源笔记升级 3.8.2 后日历插件无法打开问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
           :field-names="{ value: 'id', label: 'name' }"
           :style="{ width: '160px', margin: 'auto' }"
           :placeholder="i18n.placeholder"
+          :trigger-props="{ contentClass: 'arco-calendar-notebook-dropdown' }"
           allow-search
         >
         </a-select>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <a-config-provider :locale="locale">
-    <a-tabs style="width: 280px">
+    <a-tabs style="width: 100%">
       <template #extra>
         <a-select
           v-model="selectNotebookId"
@@ -55,14 +55,16 @@ async function init() {
 }
 init();
 
-eventBus.value?.on('ws-main', async ({ detail }) => {
+const onNotebookChange = async ({ detail }: CustomEvent) => {
   const { cmd } = detail;
   if (['createnotebook', 'mount', 'unmount'].includes(cmd)) {
     await refreshSql();
     cusNotebooks.value = [];
     await init();
   }
-});
+};
+eventBus.value?.on('ws-main', onNotebookChange);
+onUnmounted(() => eventBus.value?.off('ws-main', onNotebookChange));
 
 watch(selectNotebookId, async bookId => {
   if (!bookId) {

--- a/src/hooks/useSiYuan.ts
+++ b/src/hooks/useSiYuan.ts
@@ -6,6 +6,7 @@ export const i18n = ref<I18N>({});
 
 export const isMobile = ref<boolean>(false);
 
-export const eventBus = ref<EventBus>();
+// Keep the host instance intact: Vue proxies cannot access EventBus private fields.
+export const eventBus = shallowRef<EventBus>();
 
 export const position = ref();

--- a/src/index.less
+++ b/src/index.less
@@ -27,20 +27,163 @@
 @import '@arco-design/web-vue/es/tabs/style/index.css';
 
 [data-name='Calendar'] {
-  .b3-menu__item {
-    &,
-    &--current {
-      background-color: transparent !important;
-      height: auto !important;
-      width: auto !important;
-      padding: 0;
-    }
-  }
-
-  .arco-select-view-single,
-  .arco-picker-week-list {
-    box-sizing: border-box !important;
-  }
+  box-sizing: border-box;
+  width: 304px !important;
+  max-width: calc(100vw - 16px) !important;
+  min-height: 0 !important;
+  max-height: min(560px, calc(100vh - 16px)) !important;
+  padding: 10px !important;
+  overflow: auto !important;
+  border: 1px solid var(--b3-border-color) !important;
+  border-radius: 12px !important;
+  background: var(--b3-menu-background) !important;
+  box-shadow:
+    0 14px 36px #00000042,
+    0 2px 10px #00000024 !important;
+}
+[data-name='Calendar'] .b3-menu__item,
+[data-name='Calendar'] .b3-menu__item--current {
+  background-color: transparent !important;
+  height: auto !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border-radius: 8px !important;
+}
+[data-name='Calendar'] .arco-tabs {
+  width: 100%;
+  background: transparent;
+}
+[data-name='Calendar'] .arco-tabs-nav {
+  padding: 0 4px 8px;
+  border-bottom: 1px solid var(--b3-border-color);
+}
+[data-name='Calendar'] .arco-tabs-tab {
+  padding: 2px 0;
+  color: var(--b3-theme-on-background);
+  font-size: 15px;
+  font-weight: 600;
+}
+[data-name='Calendar'] .arco-tabs-content,
+[data-name='Calendar'] .arco-tabs-content-list,
+[data-name='Calendar'] .arco-tabs-content-item,
+[data-name='Calendar'] .arco-tabs-pane {
+  box-sizing: border-box !important;
+  width: 100% !important;
+  min-width: 0 !important;
+}
+[data-name='Calendar'] .arco-tabs-content {
+  padding-top: 10px;
+}
+[data-name='Calendar'] .arco-select-view {
+  box-sizing: border-box;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--b3-border-color);
+  border-radius: 8px;
+  background: var(--b3-list-hover);
+  color: var(--b3-theme-on-background);
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    box-shadow 0.16s ease;
+}
+[data-name='Calendar'] .arco-select-view:hover {
+  border-color: var(--b3-theme-primary);
+}
+[data-name='Calendar'] .arco-select-view:focus-within {
+  border-color: var(--b3-theme-primary);
+  box-shadow: 0 0 0 3px var(--b3-theme-primary-lightest);
+}
+[data-name='Calendar'] .arco-picker {
+  width: 100% !important;
+  max-width: none !important;
+  box-sizing: border-box;
+  padding: 8px 6px 0 !important;
+  background: transparent !important;
+}
+[data-name='Calendar'] .arco-picker-header {
+  height: 34px;
+  padding: 0 2px 8px;
+}
+[data-name='Calendar'] .arco-picker-header-value {
+  color: var(--b3-theme-on-background);
+  font-size: 14px;
+  font-weight: 600;
+}
+[data-name='Calendar'] .arco-picker-header-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  color: var(--b3-theme-on-surface);
+  transition:
+    background-color 0.16s ease,
+    color 0.16s ease;
+}
+[data-name='Calendar'] .arco-picker-header-icon:hover {
+  background: var(--b3-list-hover);
+  color: var(--b3-theme-primary);
+}
+[data-name='Calendar'] .arco-picker-week-list {
+  padding: 0 0 4px;
+  color: var(--b3-theme-on-surface);
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0.7;
+}
+[data-name='Calendar'] .arco-picker-cell {
+  height: 34px;
+}
+[data-name='Calendar'] .arco-picker-cell .arco-picker-date-value {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 30px;
+  height: 30px;
+  margin: auto;
+  border-radius: 8px;
+  font-size: 13px;
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease,
+    transform 0.16s ease;
+}
+[data-name='Calendar'] .arco-picker-cell.arco-picker-cell-in-view .arco-picker-date-value:hover {
+  transform: translateY(-1px);
+}
+[data-name='Calendar'] .arco-picker-cell.arco-picker-cell-selected .arco-picker-date-value {
+  border-color: var(--b3-theme-primary) !important;
+  background: var(--b3-theme-primary) !important;
+  color: var(--b3-theme-background) !important;
+  box-shadow: 0 3px 8px #0000002e;
+}
+[data-name='Calendar'] .arco-picker-footer {
+  padding: 10px 0 2px;
+  border-top: 1px solid var(--b3-border-color);
+}
+[data-name='Calendar'] .arco-picker-footer .arco-btn {
+  height: 30px;
+  padding: 0 14px;
+  border: 1px solid var(--b3-border-color);
+  border-radius: 8px;
+  background: var(--b3-list-hover);
+  color: var(--b3-theme-on-background);
+  font-size: 13px;
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease;
+}
+[data-name='Calendar'] .arco-picker-footer .arco-btn:hover {
+  border-color: var(--b3-theme-primary);
+  background: var(--b3-theme-primary-lightest);
+  color: var(--b3-theme-primary);
+}
+[data-name='Calendar'] .arco-select-view-single,
+[data-name='Calendar'] .arco-picker-week-list {
+  box-sizing: border-box !important;
 }
 .arco-tabs,
 .arco-trigger-popup {

--- a/src/index.less
+++ b/src/index.less
@@ -127,6 +127,12 @@
   }
 }
 
+// The dropdown is teleported outside the calendar panel. Keep it above panels
+// using z-index: 99999 and override Arco's inline popup z-index only for this select.
+.arco-trigger-popup:has(.arco-calendar-notebook-dropdown) {
+  z-index: 100000 !important;
+}
+
 .arco-select-dropdown {
   padding: 6px !important;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
+import type { App as VueApp } from 'vue';
 import App from './App.vue';
-import { Plugin, Menu, Setting, getFrontend } from 'siyuan';
+import { Plugin, Setting, getFrontend } from 'siyuan';
 import { app, i18n, isMobile, eventBus, position } from './hooks/useSiYuan';
 import SySelect from './lib/SySelect.vue';
 import './index.less';
@@ -8,7 +9,9 @@ const STORAGE_NAME = 'arco-calendar-entry';
 
 export default class ArcoCalendarPlugin extends Plugin {
   private topEle!: HTMLElement;
-  private menuEle!: HTMLElement;
+  private calendarPopup?: HTMLElement;
+  private calendarApp?: VueApp;
+  private removePopupListeners?: () => void;
 
   onload() {
     i18n.value = this.i18n;
@@ -20,7 +23,7 @@ export default class ArcoCalendarPlugin extends Plugin {
 
   onunload() {
     this.topEle?.remove();
-    this.menuEle?.remove();
+    this.closeCalendar();
   }
 
   private async init() {
@@ -61,32 +64,79 @@ export default class ArcoCalendarPlugin extends Plugin {
     });
   }
 
+  private closeCalendar() {
+    this.removePopupListeners?.();
+    this.removePopupListeners = undefined;
+    this.calendarApp?.unmount();
+    this.calendarApp = undefined;
+    this.calendarPopup?.remove();
+    this.calendarPopup = undefined;
+  }
+
   private addTopItem(direction: 'left' | 'right') {
     this.topEle = this.addTopBar({
       icon: 'iconCalendar',
       title: this.i18n.openCalendar,
       position: direction,
       callback: () => {
+        if (this.calendarPopup) {
+          this.closeCalendar();
+          return;
+        }
         let rect = this.topEle.getBoundingClientRect();
-        // 如果被隐藏，则使用更多按钮
-        if (rect.width === 0) {
-          rect = document.querySelector('#barMore')!.getBoundingClientRect();
-        }
-        const menu = new Menu('Calendar');
-        menu.addItem({ element: this.menuEle });
-        if (isMobile.value) {
-          menu.fullscreen();
-        } else {
-          menu.open({
-            x: rect[direction],
-            y: rect.bottom,
-            isLeft: direction !== 'left',
-          });
-        }
+        const moreButton = document.querySelector('#barMore');
+        if (rect.width === 0 && moreButton) rect = moreButton.getBoundingClientRect();
+        // Mount directly: passing the Vue root through Menu can produce an empty
+        // panel in newer SiYuan versions. This restores the working backup behavior.
+        const width = Math.min(304, window.innerWidth - 16);
+        const popup = document.createElement('div');
+        popup.className = 'b3-menu arco-calendar-popup';
+        popup.dataset.name = 'Calendar';
+        popup.setAttribute('role', 'dialog');
+        popup.setAttribute('aria-label', this.i18n.tabName);
+        Object.assign(popup.style, {
+          position: 'fixed',
+          zIndex: '99999',
+          display: 'block',
+          visibility: 'visible',
+          opacity: '1',
+          pointerEvents: 'auto',
+          width: `${width}px`,
+          minHeight: '0',
+          overflow: 'auto',
+          left: `${Math.max(8, Math.min(direction === 'left' ? rect.left : rect.right - width, window.innerWidth - width - 8))}px`,
+          top: `${Math.max(8, Math.min(rect.bottom, window.innerHeight - 520))}px`,
+        });
+        const item = document.createElement('div');
+        item.className = 'b3-menu__item';
+        Object.assign(item.style, { display: 'block', width: '100%', margin: '0', padding: '0' });
+        const root = document.createElement('div');
+        Object.assign(root.style, { width: '100%', minHeight: '420px', boxSizing: 'border-box' });
+        item.append(root);
+        popup.append(item);
+        document.body.append(popup);
+        this.calendarPopup = popup;
+        this.calendarApp = createApp(App);
+        this.calendarApp.mount(root);
+        const onOutsideClick = (event: MouseEvent) => {
+          const target = event.target;
+          if (!(target instanceof Node)) return;
+          // Arco teleports the dropdown outside the calendar popup.
+          const inDropdown =
+            target instanceof Element && target.closest('.arco-trigger-popup:has(.arco-calendar-notebook-dropdown)');
+          if (!popup.contains(target) && !this.topEle.contains(target) && !inDropdown) this.closeCalendar();
+        };
+        const onKeydown = (event: KeyboardEvent) => {
+          if (event.key === 'Escape') this.closeCalendar();
+        };
+        document.addEventListener('mousedown', onOutsideClick, true);
+        document.addEventListener('keydown', onKeydown);
+        this.removePopupListeners = () => {
+          document.removeEventListener('mousedown', onOutsideClick, true);
+          document.removeEventListener('keydown', onKeydown);
+        };
       },
     });
-    this.menuEle = document.createElement('div');
-    createApp(App).mount(this.menuEle);
   }
 
   private addDockItem() {


### PR DESCRIPTION
修复思源笔记升级 3.8.2 后日历插件无法打开问题